### PR TITLE
添加对WebP图像转换为JPG图像的支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ A fanmade literary journal based on mobile game *Arknights*, redesigned for vint
 
 Enjoy~
 
+## About WebP image support for vintage devices...
+Most vintage devices don't support WebP image, so WebP image can't be displayed on these devices.
+
+To solve this problem, we can dynamically convert WebP image to JPEG image, but due to performance <!-- and copyright [I don't know whether AnEoT's offical members allow me to do this, even dynamically] -->  reason, this function is disabled by default.
+
+To enable it, use the following method to do that (ordered by the priority)
+>	- Use *command line argument*:
+> ```dotnet run --ConvertWebP true```
+> - Set *environment variables* named ```ConvertWebP```: set it in ```launchSettings.json``` or in your command line interface
+> 
+> - Add ```ConvertWebP``` in *appsettings.json*
+> ```
+> {
+>	......
+>  "ConvertWebP": true
+>	......
+> }
+> ```
+
+This configuration will affect static web site generation.
+
 ## About Us
 
 If there are any errors in the website or you have any comments,

--- a/src/AnEoT.Vintage.csproj
+++ b/src/AnEoT.Vintage.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.SassCompiler" Version="1.63.6" />
     <PackageReference Include="AspNetStatic" Version="0.13.3" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.1.3" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.7" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/src/AnEoT.Vintage.csproj
+++ b/src/AnEoT.Vintage.csproj
@@ -11,7 +11,9 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.SassCompiler" Version="1.63.6" />
     <PackageReference Include="AspNetStatic" Version="0.13.3" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.1.3" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.7" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Westwind.AspNetCore.Markdown" Version="3.11.0" />
     <PackageReference Include="YamlDotNet" Version="13.1.1" />

--- a/src/Helpers/Custom/CustomHtmlRenderer.cs
+++ b/src/Helpers/Custom/CustomHtmlRenderer.cs
@@ -11,13 +11,12 @@ namespace AnEoT.Vintage.Helpers.Custom
         /// <summary>
         /// 使用指定的参数构造<seealso cref="CustomHtmlRenderer"/>的新实例
         /// </summary>
-        /// <param name="writer"></param>
-        public CustomHtmlRenderer(TextWriter writer) : base(writer)
+        public CustomHtmlRenderer(TextWriter writer, bool convertWebP) : base(writer)
         {
             IMarkdownObjectRenderer target = ObjectRenderers.First(obj => obj is LinkInlineRenderer);
             
             int targetIndex = ObjectRenderers.IndexOf(target);
-            ObjectRenderers.Insert(targetIndex, new CustomLinkInlineRenderer());
+            ObjectRenderers.Insert(targetIndex, new CustomLinkInlineRenderer(convertWebP));
             ObjectRenderers.Remove(target);
         }
     }

--- a/src/Helpers/Custom/CustomLinkInlineRenderer.cs
+++ b/src/Helpers/Custom/CustomLinkInlineRenderer.cs
@@ -11,12 +11,27 @@ namespace AnEoT.Vintage.Helpers.Custom
     /// </summary>
     public class CustomLinkInlineRenderer : LinkInlineRenderer
     {
+        private readonly bool convertWebP;
+
+        /// <summary>
+        /// 使用指定的参数构造<seealso cref="CustomLinkInlineRenderer"/>的新实例
+        /// </summary>
+        public CustomLinkInlineRenderer(bool convertWebP)
+        {
+            this.convertWebP = convertWebP;
+        }
+
         /// <inheritdoc/>
         protected override void Write(HtmlRenderer renderer, LinkInline link)
         {
             if (link.Url is not null && new Uri(link.Url, UriKind.RelativeOrAbsolute).IsAbsoluteUri is not true)
             {
                 link.Url = link.Url?.Replace(".md", ".html").Replace("README", "index");
+            }
+
+            if (convertWebP && link.IsImage)
+            {
+                link.Url = link.Url?.Replace(".webp", ".jpg");
             }
 
             base.Write(renderer, link);

--- a/src/Helpers/Custom/CustomMarkdownParser.cs
+++ b/src/Helpers/Custom/CustomMarkdownParser.cs
@@ -8,13 +8,14 @@ namespace AnEoT.Vintage.Helpers.Custom
     /// </summary>
     public class CustomMarkdownParser : MarkdownParserMarkdig
     {
+        private readonly bool convertWebP;
+
         /// <summary>
         /// 使用指定的参数构造<seealso cref="CustomMarkdownParser"/>的新实例
         /// </summary>
-        /// <param name="usePragmaLines"></param>
-        /// <param name="forceLoad"></param>
-        public CustomMarkdownParser(bool usePragmaLines, bool forceLoad) : base(usePragmaLines, forceLoad)
+        public CustomMarkdownParser(bool usePragmaLines, bool forceLoad, bool convertWebP) : base(usePragmaLines, forceLoad)
         {
+            this.convertWebP = convertWebP;
         }
 
         /// <inheritdoc/>
@@ -28,7 +29,7 @@ namespace AnEoT.Vintage.Helpers.Custom
             string html;
             using (StringWriter stringWriter = new())
             {
-                IMarkdownRenderer renderer = new CustomHtmlRenderer(stringWriter);
+                IMarkdownRenderer renderer = new CustomHtmlRenderer(stringWriter, convertWebP);
                 Markdig.Markdown.Convert(markdown, renderer, Pipeline);
                 html = stringWriter.ToString();
             }

--- a/src/Helpers/Custom/CustomMarkdownParserFactory.cs
+++ b/src/Helpers/Custom/CustomMarkdownParserFactory.cs
@@ -7,6 +7,16 @@ namespace AnEoT.Vintage.Helpers.Custom
     /// </summary>
     public class CustomMarkdownParserFactory : IMarkdownParserFactory
     {
+        private bool convertWebP;
+
+        /// <summary>
+        /// 使用指定的参数构造<seealso cref="CustomMarkdownParserFactory"/>的新实例
+        /// </summary>
+        public CustomMarkdownParserFactory(bool convertWebP)
+        {
+            this.convertWebP = convertWebP;
+        }
+
         /// <inheritdoc/>
         public IMarkdownParser? CurrentParser { get; private set; }
 
@@ -18,7 +28,7 @@ namespace AnEoT.Vintage.Helpers.Custom
                 return CurrentParser;
             }
 
-            CurrentParser = new CustomMarkdownParser(usePragmaLines, forceLoad);
+            CurrentParser = new CustomMarkdownParser(usePragmaLines, forceLoad, convertWebP);
             return CurrentParser;
         }
     }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -168,7 +168,10 @@ namespace AnEoT.Vintage
                     {
                         string acceptHeader = context.Context.Request.Headers["Accept"].ToString();
 
-                        if (!acceptHeader.Contains("image/webp") && context.File.Name.EndsWith(".webp") && context.Context.Response.StatusCode != StatusCodes.Status304NotModified)
+                        if (!acceptHeader.Contains("image/webp")
+                            && context.File.Name.EndsWith(".webp")
+                            && context.Context.Response.StatusCode != StatusCodes.Status304NotModified
+                            && context.File.PhysicalPath is not null)
                         {
                             context.Context.Response.Headers.Remove("Content-Length");
 

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -6,5 +6,6 @@
     }
   },
   "AllowedHosts": "*",
-  "StaticWebSiteOutputPath": ""
+  "StaticWebSiteOutputPath": "",
+  "ConvertWebP": "Type true or false here, remember to remove quotation marks"
 }


### PR DESCRIPTION
现在支持将WebP图像转换为JPG图像（动态网页与静态网页皆可）

不过，此功能需要手动启用。

要启用，请使用下面的方法（按优先度排序）

> - 命令行参数
> ```dotnet run --ConvertWebP true```
> - 设置名为 ```ConvertWebP``` 的环境变量：在 ```launchSettings.json``` 或在命令行界面设置均可
> 
> - 在appsettings.json中添加 ```ConvertWebP```
> ```
> {
>	......
>  "ConvertWebP": true
>	......
> }
> ```