### PR TITLE
重新启用大部分环境的 HTTPS 支持

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: dotnet run --project ./src/AnEoT.Vintage.csproj -- static-only --ConvertWebP true
+      run: dotnet run --project ./src/AnEoT.Vintage.csproj -- static-only --ConvertWebP true --urls "http://localhost:5048"
     - name: Setup Pages
       uses: actions/configure-pages@v3
     - name: Upload artifact

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -7,7 +7,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5048"
+      "applicationUrl": "http://localhost:5048;https://localhost:7012"
     },
     "IIS Express": {
       "commandName": "IISExpress",
@@ -22,7 +22,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:5048",
+      "applicationUrl": "http://localhost:5048;https://localhost:7012",
       "sslPort": 7012
     }
   }


### PR DESCRIPTION
现在，仅在 GitHub Actions 环境中禁用 HTTPS，其他环境下默认启用 HTTPS 支持。