### PR TITLE
修复带透明度的图像显示不正常的问题

### DIFF
--- a/src/Helpers/StaticWebSiteHelper.cs
+++ b/src/Helpers/StaticWebSiteHelper.cs
@@ -125,8 +125,11 @@ namespace AnEoT.Vintage.Helpers
             {
                 if (convertWebp && file.Extension.Equals(".webp"))
                 {
+                    Console.WriteLine($"正在转换：{file.Name}");
+
                     string targetFilePath = Path.Combine(destinationDir, Path.ChangeExtension(file.Name, ".jpg"));
                     using Image image = Image.Load(file.FullName);
+                    image.Mutate(x => x.BackgroundColor(Color.White));
                     image.SaveAsJpeg(targetFilePath);
                 }
                 else

--- a/src/Views/Home/Index.cshtml
+++ b/src/Views/Home/Index.cshtml
@@ -12,14 +12,7 @@
             <li style="margin:0 0 10px 0">
                 @item.Name
                 <br/>
-                @if (new Uri(item.Link, UriKind.RelativeOrAbsolute).IsAbsoluteUri)
-                {
-                    <a href="@item.Link">@item.Desc</a>
-                }
-                else
-                {
-                    <a href="~/@item.Link">@item.Desc</a>
-                }
+                <a href="@item.Link">@item.Desc</a>
             </li>
         }
     </ul>


### PR DESCRIPTION
- 修复带透明度的图像转换后显示不正常的问题
- 更改主页面链接的逻辑（为了在 GitHub Pages 中正确导航到指定的页面）