### PR TITLE
修复 GitHub Pages 上静态网页的导航栏

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,10 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: 预处理
+    - name: 预处理-移除不需要的组件
       run: dotnet run --configuration Release --project ./src/AnEoT.Vintage.Tool/AnEoT.Vintage.Tool.csproj remove-unnecessary-component --webroot-path ${{ github.workspace }}/src/AnEoT.Vintage/wwwroot
     - name: 构建主项目及生成静态网页
       run: dotnet run --configuration Release --project ./src/AnEoT.Vintage/AnEoT.Vintage.csproj -- static-only --ConvertWebP true --urls "http://localhost:5048"
+    - name: 后期处理-修复 GitHub Pages 环境的导航栏
+      run: dotnet run --configuration Release --project ./src/AnEoT.Vintage.Tool/AnEoT.Vintage.Tool.csproj fix-navbar --static-content-path ${{ github.workspace }}/src/AnEoT.Vintage/StaticWebSite
     - name: 配置 GitHub Pages
       uses: actions/configure-pages@v3
     - name: 上传生成的静态网页

--- a/src/AnEoT.Vintage.Tool/AnEoT.Vintage.Tool.csproj
+++ b/src/AnEoT.Vintage.Tool/AnEoT.Vintage.Tool.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.0.4" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/src/AnEoT.Vintage.Tool/NavBarFix.cs
+++ b/src/AnEoT.Vintage.Tool/NavBarFix.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using AngleSharp.Dom;
+using AngleSharp.Html;
+using AngleSharp.Html.Dom;
+using AngleSharp.Html.Parser;
 
 namespace AnEoT.Vintage.Tool
 {
@@ -15,6 +14,8 @@ namespace AnEoT.Vintage.Tool
         {
             Console.WriteLine("正在修改导航栏以适配 GitHub Pages...");
             DirectoryInfo staticContentDirectory = new(staticContentPath);
+
+            ModifyRecursively(staticContentDirectory);
         }
 
         private static void ModifyRecursively(DirectoryInfo directory)
@@ -22,7 +23,7 @@ namespace AnEoT.Vintage.Tool
             //目标：当前文件夹中的文件
             foreach (FileInfo file in directory.EnumerateFiles("*.html"))
             {
-                
+                ModifyNavBarLinks(file);
             }
 
             foreach (DirectoryInfo subDirectory in directory.EnumerateDirectories())
@@ -30,11 +31,71 @@ namespace AnEoT.Vintage.Tool
                 //目标：子文件夹中的文件
                 foreach (FileInfo file in subDirectory.EnumerateFiles("*.html"))
                 {
-                    
+                    ModifyNavBarLinks(file);
                 }
 
                 //递归：对子文件夹的子文件夹进行操作
                 ModifyRecursively(subDirectory);
+            }
+        }
+
+        private static void ModifyNavBarLinks(FileInfo file)
+        {
+            string html = File.ReadAllText(file.FullName);
+            HtmlParser parser = new();
+
+            using IHtmlDocument document = parser.ParseDocument(html);
+            IEnumerable<IElement> navBarLinks = document.All
+                .Where(element => element.TagName.ToUpperInvariant() is "A" or "IMG" or "LINK");
+
+            bool isModified = false;
+
+            foreach (IElement item in navBarLinks)
+            {
+                switch (item)
+                {
+                    case IHtmlAnchorElement anchor:
+                        string? originalHref = anchor.GetAttribute("href");
+                        if (originalHref is not null && originalHref.StartsWith('/'))
+                        {
+                            anchor.SetAttribute("href", $"/aneot-vintage{originalHref}");
+                            isModified = true;
+                        }
+                        break;
+                    case IHtmlImageElement image:
+                        string? originalSrc = image.GetAttribute("src");
+                        if (originalSrc is not null && originalSrc.StartsWith('/'))
+                        {
+                            image.SetAttribute("src", $"/aneot-vintage{originalSrc}");
+                            isModified = true;
+                        }
+                        break;
+                    case IHtmlLinkElement link:
+                        string? originalLink = link.GetAttribute("href");
+                        if (originalLink is not null && originalLink.StartsWith('/'))
+                        {
+                            link.SetAttribute("src", $"/aneot-vintage{originalLink}");
+                            isModified = true;
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            if (isModified)
+            {
+                using StreamWriter writer = File.CreateText(file.FullName);
+                
+                //这样既能保留IE条件注释又能压缩文件
+                PrettyMarkupFormatter formatter = new()
+                {
+                    NewLine = string.Empty,
+                    Indentation = string.Empty,
+                };
+                document.ToHtml(writer, formatter);
+
+                Console.WriteLine($"已修改文件 {file.FullName}");
             }
         }
     }

--- a/src/AnEoT.Vintage.Tool/NavBarFix.cs
+++ b/src/AnEoT.Vintage.Tool/NavBarFix.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnEoT.Vintage.Tool
+{
+    /// <summary>
+    /// 为修改导航栏提供帮助的类
+    /// </summary>
+    internal static class NavBarFix
+    {
+        public static void FixNavBar(string staticContentPath)
+        {
+            Console.WriteLine("正在修改导航栏以适配 GitHub Pages...");
+            DirectoryInfo staticContentDirectory = new(staticContentPath);
+        }
+
+        private static void ModifyRecursively(DirectoryInfo directory)
+        {
+            //目标：当前文件夹中的文件
+            foreach (FileInfo file in directory.EnumerateFiles("*.html"))
+            {
+                
+            }
+
+            foreach (DirectoryInfo subDirectory in directory.EnumerateDirectories())
+            {
+                //目标：子文件夹中的文件
+                foreach (FileInfo file in subDirectory.EnumerateFiles("*.html"))
+                {
+                    
+                }
+
+                //递归：对子文件夹的子文件夹进行操作
+                ModifyRecursively(subDirectory);
+            }
+        }
+    }
+}

--- a/src/AnEoT.Vintage.Tool/Program.cs
+++ b/src/AnEoT.Vintage.Tool/Program.cs
@@ -60,7 +60,7 @@ internal sealed class Program
             NavBarFix.FixNavBar(staticWebSitePath);
             Console.WriteLine();
             Console.WriteLine("操作成功完成。");
-        }, webRootPathOption);
+        }, staticWebSiteOutputPathOption);
 
         rootCommand.AddCommand(removeUnnecessaryComponentCommand);
         rootCommand.AddCommand(fixNavBarCommand);

--- a/src/AnEoT.Vintage.Tool/Program.cs
+++ b/src/AnEoT.Vintage.Tool/Program.cs
@@ -23,10 +23,24 @@ internal sealed class Program
             }
         });
         
-        Command removeForceFlashCommand = new("remove-unnecessary-component", "移除不需要的文件及其引用。");
-        removeForceFlashCommand.AddAlias("ruc");
-        removeForceFlashCommand.AddOption(webRootPathOption);
-        removeForceFlashCommand.SetHandler(wwwrootPath =>
+        Option<string> staticWebSiteOutputPathOption = new(
+            name: "--static-content-path",
+            description: "目标输出静态网页文件夹的路径")
+        { IsRequired = true };
+
+        staticWebSiteOutputPathOption.AddValidator(result =>
+        {
+            string? filePath = result.GetValueForOption(staticWebSiteOutputPathOption);
+            if (!Directory.Exists(filePath))
+            {
+                result.ErrorMessage = "指定的目录不存在，传入路径：{filePath}";
+                return;
+            }
+        });
+        
+        Command removeUnnecessaryComponentCommand = new("remove-unnecessary-component", "移除不需要的文件及其引用。");
+        removeUnnecessaryComponentCommand.AddOption(webRootPathOption);
+        removeUnnecessaryComponentCommand.SetHandler(wwwrootPath =>
         {
             Console.WriteLine($"工作目录：{wwwrootPath}");
             Console.WriteLine("======");
@@ -36,8 +50,20 @@ internal sealed class Program
             Console.WriteLine();
             Console.WriteLine("操作成功完成。");
         }, webRootPathOption);
+        
+        Command fixNavBarCommand = new("fix-navbar", "修复静态网页在 GitHub Pages 中的导航栏问题。");
+        fixNavBarCommand.AddOption(staticWebSiteOutputPathOption);
+        fixNavBarCommand.SetHandler(staticWebSitePath =>
+        {
+            Console.WriteLine($"工作目录：{staticWebSitePath}");
+            Console.WriteLine("======");
+            NavBarFix.FixNavBar(staticWebSitePath);
+            Console.WriteLine();
+            Console.WriteLine("操作成功完成。");
+        }, webRootPathOption);
 
-        rootCommand.AddCommand(removeForceFlashCommand);
+        rootCommand.AddCommand(removeUnnecessaryComponentCommand);
+        rootCommand.AddCommand(fixNavBarCommand);
 
         return rootCommand.InvokeAsync(args).Result;
     }


### PR DESCRIPTION
目前，通过 GitHub Actions 部署的网站 (https://baka632.github.io/aneot-vintage) 大部分功能工作正常，但是其导航栏链接会指向即将弃用的 https://baka632.github.io 。

其原是 @Baka632 的已存档的个人博客，我们在实现静态网页文件时将其用于《回归线》简易版的示例网站，现在，我们将此网站移动到本仓库的 GitHub Pages中。

为了彻底地完成迁移，我们应当修复这个问题。
