### PR TITLE
修复 RSS 源生成顺序问题

### DIFF
--- a/src/AnEoT.Vintage/Helpers/StaticWebSiteHelper.cs
+++ b/src/AnEoT.Vintage/Helpers/StaticWebSiteHelper.cs
@@ -1,151 +1,70 @@
 ﻿using AspNetStatic;
 
-namespace AnEoT.Vintage.Helpers
+namespace AnEoT.Vintage.Helpers;
+
+/// <summary>
+/// 为静态网页生成提供帮助方法
+/// </summary>
+public static class StaticWebSiteHelper
 {
     /// <summary>
-    /// 为静态网页生成提供帮助方法
+    /// 获取用于描述网站内容的<see cref="StaticPagesInfoProvider"/>
     /// </summary>
-    public static class StaticWebSiteHelper
+    /// <returns>描述网站内容的<see cref="StaticPagesInfoProvider"/></returns>
+    public static StaticPagesInfoProvider GetStaticPagesInfoProvider(string webRootPath)
     {
-        /// <summary>
-        /// 获取用于描述网站内容的<see cref="StaticPagesInfoProvider"/>，并且复制必需的文件
-        /// </summary>
-        /// <param name="webRootPath">“wwwroot”文件夹所在路径</param>
-        /// <param name="outputPath">静态网页的输出路径</param>
-        /// <param name="convertWebpToJpg">指示是否将WebP图像转换为JPG图像的值</param>
-        /// <returns>描述网站内容的<see cref="StaticPagesInfoProvider"/></returns>
-        public static StaticPagesInfoProvider GetStaticPagesInfoProviderAndCopyFiles(string webRootPath, string outputPath, bool convertWebpToJpg)
+        List<PageInfo> pages = new(2000)
         {
-            List<PageInfo> pages = new(2000)
+            new PageInfo("/"),
+            new PageInfo("/posts") { OutFile = Path.Combine("posts","index.html") },
+        };
+
+        DirectoryInfo wwwRootDirectory = new(webRootPath);
+
+        #region 第一步：根据wwwroot下的Markdown文件来生成网页内容信息
+        foreach (FileInfo item in wwwRootDirectory.EnumerateFiles("*.md"))
+        {
+            //去掉Homepage.md，因为前面已经间接添加过了
+            if (item.Name.Contains("Homepage.md"))
             {
-                new PageInfo("/"),
-                new PageInfo("/posts") { OutFile = Path.Combine("posts","index.html") },
+                continue;
+            }
+
+            string nameRemovedExtension = item.Name.Replace(".md", string.Empty);
+            pages.Add(new($"/{nameRemovedExtension}"));
+        }
+        #endregion
+
+        #region 第二步：根据wwwroot\posts下的文件与文件夹来生成网页内容信息
+        //获取posts文件夹的信息
+        DirectoryInfo postsDirectoryInfo = new(Path.Combine(webRootPath, "posts"));
+
+        foreach (DirectoryInfo volDirInfo in postsDirectoryInfo.EnumerateDirectories())
+        {
+            //添加各期刊页面的信息
+            PageInfo info = new($"/posts/{volDirInfo.Name}")
+            {
+                OutFile = Path.Combine("posts", volDirInfo.Name, "index.html")
             };
 
-            DirectoryInfo wwwRootDirectory = new(webRootPath);
+            pages.Add(info);
 
-            #region 第一步：根据wwwroot下的Markdown文件来生成网页内容信息
-            foreach (FileInfo item in wwwRootDirectory.EnumerateFiles("*.md"))
+            //添加特定期刊下的文章的信息
+            foreach (FileInfo article in volDirInfo.EnumerateFiles("*.md"))
             {
-                //去掉Homepage.md，因为前面已经间接添加过了
-                if (item.Name.Contains("Homepage.md"))
+                //去掉README.md，因为前面已经间接添加过了
+                if (article.Name.Contains("README.md"))
                 {
                     continue;
                 }
 
-                string nameRemovedExtension = item.Name.Replace(".md", string.Empty);
-                pages.Add(new($"/{nameRemovedExtension}"));
-            }
-            #endregion
-
-            #region 第二步：根据wwwroot\posts下的文件与文件夹来生成网页内容信息
-            //获取posts文件夹的信息
-            DirectoryInfo postsDirectoryInfo = new(Path.Combine(webRootPath, "posts"));
-
-            foreach (DirectoryInfo volDirInfo in postsDirectoryInfo.EnumerateDirectories())
-            {
-                //添加期刊页面的信息
-                PageInfo info = new($"/posts/{volDirInfo.Name}")
-                {
-                    OutFile = Path.Combine("posts", volDirInfo.Name, "index.html")
-                };
-
-                pages.Add(info);
-
-                //添加特定期刊下的文章的信息
-                foreach (FileInfo article in volDirInfo.EnumerateFiles("*.md"))
-                {
-                    //去掉README.md，因为前面已经间接添加过了
-                    if (article.Name.Contains("README.md"))
-                    {
-                        continue;
-                    }
-
-                    string nameRemovedExtension = article.Name.Replace(".md", string.Empty);
-                    pages.Add(new($"/posts/{volDirInfo.Name}/{nameRemovedExtension}"));
-                }
-
-                //复制特定期刊的静态文件
-                DirectoryInfo resDirInfo = new(Path.Combine(Path.Combine(volDirInfo.FullName, "res")));
-                if (resDirInfo.Exists)
-                {
-                    CopyDirectory(resDirInfo, Path.Combine(outputPath, "posts", volDirInfo.Name, "res"), true, convertWebpToJpg);
-                }
-            }
-            #endregion
-
-            #region 第三步：复制必需的静态文件
-            //复制wwwroot下的文件夹（无posts文件夹）
-            IEnumerable<DirectoryInfo> directories = wwwRootDirectory.EnumerateDirectories()
-                .Where(dir => !dir.Name.Contains("posts"));
-
-            foreach (DirectoryInfo item in directories)
-            {
-                CopyDirectory(item, Path.Combine(outputPath, item.Name), true, convertWebpToJpg);
-            }
-
-            //复制非md扩展名的文件
-            IEnumerable<FileInfo> fileInfos = wwwRootDirectory.EnumerateFiles().Where(file => file.Extension != ".md");
-            foreach (FileInfo fileInfo in fileInfos)
-            {
-                string targetFilePath = Path.Combine(outputPath, fileInfo.Name);
-                fileInfo.CopyTo(targetFilePath, true);
-            }
-            #endregion
-
-            StaticPagesInfoProvider provider = new(pages);
-            return provider;
-        }
-
-        /// <summary>
-        /// 复制目录
-        /// </summary>
-        /// <param name="sourceDir">原目录信息</param>
-        /// <param name="destinationDir">目标目录路径</param>
-        /// <param name="recursive">指示是否复制子目录的值</param>
-        /// <param name="convertWebp">指示是否对文件夹中的WebP图像进行转换的值</param>
-        /// <exception cref="DirectoryNotFoundException">当找不到指定的文件夹时抛出</exception>
-        private static void CopyDirectory(DirectoryInfo sourceDir, string destinationDir, bool recursive, bool convertWebp)
-        {
-            //源代码来自：https://learn.microsoft.com/dotnet/standard/io/how-to-copy-directories
-
-            DirectoryInfo dir = sourceDir;
-
-            if (!dir.Exists)
-            {
-                throw new DirectoryNotFoundException($"找不到目录: {dir.FullName}");
-            }
-
-            DirectoryInfo[] dirs = dir.GetDirectories();
-
-            Directory.CreateDirectory(destinationDir);
-
-            foreach (FileInfo file in dir.GetFiles())
-            {
-                if (convertWebp && file.Extension.Equals(".webp", StringComparison.OrdinalIgnoreCase))
-                {
-                    Console.WriteLine($"正在转换：{file.Name}");
-
-                    string targetFilePath = Path.Combine(destinationDir, Path.ChangeExtension(file.Name, ".jpg"));
-                    using Image image = Image.Load(file.FullName);
-                    image.Mutate(x => x.BackgroundColor(Color.White));
-                    image.SaveAsJpeg(targetFilePath);
-                }
-                else
-                {
-                    string targetFilePath = Path.Combine(destinationDir, file.Name);
-                    file.CopyTo(targetFilePath, true);
-                }
-            }
-
-            if (recursive)
-            {
-                foreach (DirectoryInfo subDir in dirs)
-                {
-                    string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
-                    CopyDirectory(subDir, newDestinationDir, true, convertWebp);
-                }
+                string nameRemovedExtension = article.Name.Replace(".md", string.Empty);
+                pages.Add(new($"/posts/{volDirInfo.Name}/{nameRemovedExtension}"));
             }
         }
+        #endregion
+
+        StaticPagesInfoProvider provider = new(pages);
+        return provider;
     }
 }

--- a/src/AnEoT.Vintage/Helpers/WebRootFileHelper.cs
+++ b/src/AnEoT.Vintage/Helpers/WebRootFileHelper.cs
@@ -1,0 +1,101 @@
+﻿namespace AnEoT.Vintage.Helpers;
+
+/// <summary>
+/// 为"wwwroot"文件夹内文件的相关操作提供帮助方法
+/// </summary>
+public static class WebRootFileHelper
+{
+    /// <summary>
+    /// 将"wwwroot"文件夹内对静态网页所必需的文件复制到指定的目录中
+    /// </summary>
+    /// <param name="webRootPath">“wwwroot”文件夹所在路径</param>
+    /// <param name="outputPath">静态网页的输出路径</param>
+    /// <param name="convertWebpToJpg">指示是否将 WebP 图像转换为 JPG 图像的值</param>
+    public static void CopyFilesToStaticWebSiteOutputPath(string webRootPath, string outputPath, bool convertWebpToJpg)
+    {
+        DirectoryInfo wwwRootDirectory = new(webRootPath);
+        DirectoryInfo postsDirectoryInfo = new(Path.Combine(webRootPath, "posts"));
+
+        #region 复制特定期刊的资源文件
+        foreach (DirectoryInfo volDirInfo in postsDirectoryInfo.EnumerateDirectories())
+        {
+            //复制特定期刊的静态文件
+            DirectoryInfo resDirInfo = new(Path.Combine(volDirInfo.FullName, "res"));
+            if (resDirInfo.Exists)
+            {
+                CopyDirectory(resDirInfo, Path.Combine(outputPath, "posts", volDirInfo.Name, "res"), true, convertWebpToJpg);
+            }
+        }
+        #endregion
+
+        #region 复制wwwroot下的文件夹与文件
+        //复制wwwroot下的文件夹（无posts文件夹）
+        IEnumerable<DirectoryInfo> directories = wwwRootDirectory.EnumerateDirectories()
+            .Where(dir => !dir.Name.Contains("posts"));
+
+        foreach (DirectoryInfo item in directories)
+        {
+            CopyDirectory(item, Path.Combine(outputPath, item.Name), true, convertWebpToJpg);
+        }
+
+        //复制非md扩展名的文件
+        IEnumerable<FileInfo> fileInfos = wwwRootDirectory.EnumerateFiles().Where(file => file.Extension != ".md");
+        foreach (FileInfo fileInfo in fileInfos)
+        {
+            string targetFilePath = Path.Combine(outputPath, fileInfo.Name);
+            fileInfo.CopyTo(targetFilePath, true);
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// 复制目录
+    /// </summary>
+    /// <param name="sourceDir">原目录信息</param>
+    /// <param name="destinationDir">目标目录路径</param>
+    /// <param name="recursive">指示是否复制子目录的值</param>
+    /// <param name="convertWebp">指示是否对文件夹中的 WebP 图像进行转换的值</param>
+    /// <exception cref="DirectoryNotFoundException">当找不到指定的文件夹时抛出</exception>
+    private static void CopyDirectory(DirectoryInfo sourceDir, string destinationDir, bool recursive, bool convertWebp)
+    {
+        //源代码来自：https://learn.microsoft.com/dotnet/standard/io/how-to-copy-directories
+
+        DirectoryInfo dir = sourceDir;
+
+        if (!dir.Exists)
+        {
+            throw new DirectoryNotFoundException($"找不到目录: {dir.FullName}");
+        }
+
+        DirectoryInfo[] dirs = dir.GetDirectories();
+
+        Directory.CreateDirectory(destinationDir);
+
+        foreach (FileInfo file in dir.GetFiles())
+        {
+            if (convertWebp && file.Extension.Equals(".webp", StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine($"正在转换：{file.Name}");
+
+                string targetFilePath = Path.Combine(destinationDir, Path.ChangeExtension(file.Name, ".jpg"));
+                using Image image = Image.Load(file.FullName);
+                image.Mutate(x => x.BackgroundColor(Color.White));
+                image.SaveAsJpeg(targetFilePath);
+            }
+            else
+            {
+                string targetFilePath = Path.Combine(destinationDir, file.Name);
+                file.CopyTo(targetFilePath, true);
+            }
+        }
+
+        if (recursive)
+        {
+            foreach (DirectoryInfo subDir in dirs)
+            {
+                string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
+                CopyDirectory(subDir, newDestinationDir, true, convertWebp);
+            }
+        }
+    }
+}

--- a/src/AnEoT.Vintage/Program.cs
+++ b/src/AnEoT.Vintage/Program.cs
@@ -12,30 +12,31 @@ using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Westwind.AspNetCore.Markdown;
 
-namespace AnEoT.Vintage
+namespace AnEoT.Vintage;
+
+/// <summary>
+/// 程序启动的入口类
+/// </summary>
+public class Program
 {
     /// <summary>
-    /// 程序启动的入口类
+    /// 入口点方法
     /// </summary>
-    public class Program
+    /// <param name="args">启动时传递的参数</param>
+    public static void Main(string[] args)
     {
-        /// <summary>
-        /// 入口点方法
-        /// </summary>
-        /// <param name="args">启动时传递的参数</param>
-        public static void Main(string[] args)
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+        #region 第一步：读取应用程序配置
+
+        //设置静态页面的导出位置
+        string staticWebSiteOutputPath;
+
         {
-            WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
-
-            #region 第一步：读取应用程序配置
-
-            //设置静态页面的导出位置
-            string staticWebSiteOutputPath;
-
-            string? pathInConfig = builder.Configuration["StaticWebSiteOutputPath"];
-            if (!string.IsNullOrWhiteSpace(pathInConfig))
+            string? outputPathInConfig = builder.Configuration["StaticWebSiteOutputPath"];
+            if (!string.IsNullOrWhiteSpace(outputPathInConfig))
             {
-                staticWebSiteOutputPath = pathInConfig;
+                staticWebSiteOutputPath = outputPathInConfig;
             }
             else
             {
@@ -43,163 +44,185 @@ namespace AnEoT.Vintage
                 Directory.CreateDirectory(defaultPath);
                 staticWebSiteOutputPath = defaultPath;
             }
+        }
 
-            //确定是否生成静态网页
-            bool generateStaticWebSite = args.HasExitWhenDoneArg();
+        //确定是否生成静态网页
+        bool generateStaticWebSite = args.HasExitWhenDoneArg();
 
-            //确定是否启用WebP图像转换功能
-            _ = bool.TryParse(builder.Configuration["ConvertWebP"], out bool convertWebP);
-            #endregion
+        //确定是否启用WebP图像转换功能
+        _ = bool.TryParse(builder.Configuration["ConvertWebP"], out bool convertWebP);
 
-            #region 第二步：向依赖注入容器添加服务
+        //设置RSS源的基Uri
+        string rssBaseUri;
 
-            //添加Markdown解析服务
-            builder.Services.AddMarkdown(config =>
+        {
+            string[]? hostUrls = builder.Configuration["urls"]?.Split(';');
+            string? rssBaseUriInConfig = builder.Configuration["RssBaseUri"];
+
+            if (string.IsNullOrWhiteSpace(rssBaseUriInConfig))
             {
-                //设置Markdown中间件的工作文件夹
-                config.AddMarkdownProcessingFolder("/");
-                config.ConfigureMarkdigPipeline = builder =>
-                {
-                    builder.UseEmphasisExtras(Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Default)
-                        .UseAdvancedExtensions()
-                        .UseListExtras()
-                        .UseEmojiAndSmiley(true)
-                        .UseYamlFrontMatter();
-                };
+                rssBaseUri = hostUrls?.FirstOrDefault(x => x.StartsWith(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+                        ?? hostUrls?.FirstOrDefault(x => x.StartsWith(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                        ?? throw new InvalidOperationException("现在无法获取到基Uri");
+            }
+            else
+            {
+                rssBaseUri = rssBaseUriInConfig;
+            }
+        }
+        #endregion
 
-                if (generateStaticWebSite)
+        #region 第二步：向依赖注入容器添加服务
+
+        //添加Markdown解析服务
+        builder.Services.AddMarkdown(config =>
+        {
+            //设置Markdown中间件的工作文件夹
+            config.AddMarkdownProcessingFolder("/");
+            config.ConfigureMarkdigPipeline = builder =>
+            {
+                builder.UseEmphasisExtras(Markdig.Extensions.EmphasisExtras.EmphasisExtraOptions.Default)
+                    .UseAdvancedExtensions()
+                    .UseListExtras()
+                    .UseEmojiAndSmiley(true)
+                    .UseYamlFrontMatter();
+            };
+
+            if (generateStaticWebSite)
+            {
+                //为静态网页启用特殊的Markdown解析机制
+                config.MarkdownParserFactory = new CustomMarkdownParserFactory(convertWebP);
+            }
+        });
+        builder.Services.AddControllersWithViews()
+            .AddApplicationPart(typeof(MarkdownPageProcessorMiddleware).Assembly);
+        
+        //添加Swagger API文档
+        builder.Services.AddSwaggerGen((options) =>
+        {
+            options.SwaggerDoc("v1", new OpenApiInfo
+            {
+                Version = "v1",
+                Title = "AnEoT API",
+                Description = "《回归线》的公共API"
+            });
+
+            string xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+            options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+        });
+
+        //注入IUrlHelper服务
+        builder.Services.AddSingleton<IActionContextAccessor, ActionContextAccessor>()
+            .AddScoped(provider =>
+            {
+                return provider.GetRequiredService<IUrlHelperFactory>()
+                .GetUrlHelper(provider.GetRequiredService<IActionContextAccessor>().ActionContext!);
+            });
+        builder.Services.Configure<WebEncoderOptions>(options =>
+        {
+            options.TextEncoderSettings = new TextEncoderSettings(UnicodeRanges.All);
+        });
+
+        if (generateStaticWebSite)
+        {
+            //添加静态网站生成服务
+            StaticPagesInfoProvider provider = StaticWebSiteHelper.GetStaticPagesInfoProvider(builder.Environment.WebRootPath);
+            builder.Services.AddSingleton<IStaticPagesInfoProvider>(provider);
+        }
+
+        WebApplication app = builder.Build();
+        #endregion
+
+        #region 第三步：配置 HTTP 请求管道
+        RewriteOptions rewriteOptions = new RewriteOptions()
+            .Add(context =>
+            {
+                HttpRequest request = context.HttpContext.Request;
+
+                context.Result = RuleResult.SkipRemainingRules;
+                if (request.Path.HasValue && !request.Path.Value.Contains("swagger", StringComparison.OrdinalIgnoreCase))
                 {
-                    //为静态网页启用特殊的Markdown解析机制
-                    config.MarkdownParserFactory = new CustomMarkdownParserFactory(convertWebP);
+                    if (request.Path.Value.Contains("api", StringComparison.OrdinalIgnoreCase))
+                    {
+                        request.Path = request.Path.Value
+                            .Replace(".md", string.Empty)
+                            .Replace(".html", string.Empty);
+                    }
+                    else
+                    {
+                        request.Path = request.Path.Value.Replace(".html", ".md");
+                    }
                 }
             });
-            builder.Services.AddControllersWithViews()
-                .AddApplicationPart(typeof(MarkdownPageProcessorMiddleware).Assembly);
-            
-            //添加Swagger API文档
-            builder.Services.AddSwaggerGen((options) =>
-            {
-                options.SwaggerDoc("v1", new OpenApiInfo
-                {
-                    Version = "v1",
-                    Title = "AnEoT API",
-                    Description = "《回归线》的公共API"
-                });
+        
+        //启用Uri重写
+        app.UseRewriter(rewriteOptions);
 
-                string xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
-                options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
-            });
-
-            //注入IUrlHelper服务
-            builder.Services.AddSingleton<IActionContextAccessor, ActionContextAccessor>()
-                .AddScoped(provider =>
-                {
-                    return provider.GetRequiredService<IUrlHelperFactory>()
-                    .GetUrlHelper(provider.GetRequiredService<IActionContextAccessor>().ActionContext!);
-                });
-            builder.Services.Configure<WebEncoderOptions>(options =>
-            {
-                options.TextEncoderSettings = new TextEncoderSettings(UnicodeRanges.All);
-            });
-
-            if (generateStaticWebSite)
-            {
-                //添加静态网站生成服务
-                StaticPagesInfoProvider provider = StaticWebSiteHelper.GetStaticPagesInfoProviderAndCopyFiles(builder.Environment.WebRootPath, staticWebSiteOutputPath, convertWebP);
-                builder.Services.AddSingleton<IStaticPagesInfoProvider>(provider);
-            }
-
-            WebApplication app = builder.Build();
-            #endregion
-
-            #region 第三步：配置 HTTP 请求管道
-            RewriteOptions rewriteOptions = new RewriteOptions()
-                .Add(context =>
-                {
-                    HttpRequest request = context.HttpContext.Request;
-
-                    context.Result = RuleResult.SkipRemainingRules;
-                    if (request.Path.HasValue && !request.Path.Value.Contains("swagger", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (request.Path.Value.Contains("api", StringComparison.OrdinalIgnoreCase))
-                        {
-                            request.Path = request.Path.Value
-                                .Replace(".md", string.Empty)
-                                .Replace(".html", string.Empty);
-                        }
-                        else
-                        {
-                            request.Path = request.Path.Value.Replace(".html", ".md");
-                        }
-                    }
-                });
-            
-            //启用Uri重写
-            app.UseRewriter(rewriteOptions);
-
-            if (app.Environment.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-            else
-            {
-                app.UseExceptionHandler("/Error/HandleError");
-            }
-            app.UseStatusCodePagesWithReExecute("/Error/{0}");
-
-            app.UseSwagger();
-            app.UseSwaggerUI();
-
-            //让Markdown中间件能够自动获取到期刊页面的README.md文件
-            app.UseDefaultFiles(new DefaultFilesOptions()
-            {
-                DefaultFileNames = new string[] { "README.md", "index.html", "index.htm" }
-            });
-           
-            app.UseAuthorization();
-
-            app.UseMarkdown();
-
-            if (convertWebP)
-            {
-                app.UseStaticFiles(new StaticFileOptions
-                {
-                    OnPrepareResponse = async context =>
-                    {
-                        string acceptHeader = context.Context.Request.Headers["Accept"].ToString();
-
-                        if (!acceptHeader.Contains("image/webp", StringComparison.OrdinalIgnoreCase)
-                            && context.File.Name.EndsWith(".webp", StringComparison.OrdinalIgnoreCase)
-                            && context.Context.Response.StatusCode != StatusCodes.Status304NotModified
-                            && context.File.PhysicalPath is not null)
-                        {
-                            context.Context.Response.Headers.Remove("Content-Length");
-
-                            using Image image = Image.Load(context.File.PhysicalPath);
-                            context.Context.Response.ContentType = "image/jpeg";
-
-                            await image.SaveAsJpegAsync(context.Context.Response.Body);
-                        }
-                    }
-                });
-            }
-            else
-            {
-                app.UseStaticFiles();
-            }
-
-            app.UseRouting();
-            app.MapDefaultControllerRoute();
-
-            app.GenerateRssFeed();
-            if (generateStaticWebSite)
-            {
-                //生成静态网页文件
-                app.GenerateStaticPages(staticWebSiteOutputPath, exitWhenDone: generateStaticWebSite, dontOptimizeContent: false);
-            }
-
-            app.Run();
-            #endregion
+        if (app.Environment.IsDevelopment())
+        {
+            app.UseDeveloperExceptionPage();
         }
+        else
+        {
+            app.UseExceptionHandler("/Error/HandleError");
+        }
+        app.UseStatusCodePagesWithReExecute("/Error/{0}");
+
+        app.UseSwagger();
+        app.UseSwaggerUI();
+
+        //让Markdown中间件能够自动获取到期刊页面的README.md文件
+        app.UseDefaultFiles(new DefaultFilesOptions()
+        {
+            DefaultFileNames = new string[] { "README.md", "index.html", "index.htm" }
+        });
+       
+        app.UseAuthorization();
+
+        app.UseMarkdown();
+
+        if (convertWebP)
+        {
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                OnPrepareResponse = async context =>
+                {
+                    string acceptHeader = context.Context.Request.Headers["Accept"].ToString();
+
+                    if (!acceptHeader.Contains("image/webp", StringComparison.OrdinalIgnoreCase)
+                        && context.File.Name.EndsWith(".webp", StringComparison.OrdinalIgnoreCase)
+                        && context.Context.Response.StatusCode != StatusCodes.Status304NotModified
+                        && context.File.PhysicalPath is not null)
+                    {
+                        context.Context.Response.Headers.Remove("Content-Length");
+
+                        using Image image = Image.Load(context.File.PhysicalPath);
+                        context.Context.Response.ContentType = "image/jpeg";
+
+                        await image.SaveAsJpegAsync(context.Context.Response.Body);
+                    }
+                }
+            });
+        }
+        else
+        {
+            app.UseStaticFiles();
+        }
+
+        app.UseRouting();
+        app.MapDefaultControllerRoute();
+
+        RssGenerationHelper.GenerateRssFeed(rssBaseUri, app.Environment.WebRootPath);
+
+        if (generateStaticWebSite)
+        {
+            //复制必需的静态文件
+            WebRootFileHelper.CopyFilesToStaticWebSiteOutputPath(app.Environment.WebRootPath, staticWebSiteOutputPath, convertWebP);
+            //生成静态网页文件
+            app.GenerateStaticPages(staticWebSiteOutputPath, exitWhenDone: generateStaticWebSite, dontOptimizeContent: false);
+        }
+
+        app.Run();
+        #endregion
     }
 }


### PR DESCRIPTION
之前，RSS 源生成是在静态文件复制完成后才进行的，这导致 RSS 源无法部署到静态网站中（或者将以前版本的 RSS 源复制过去了）

现在，修复了这个问题。