### PR TITLE
修复分类相关问题

### DIFF
--- a/src/AnEoT.Vintage/Helpers/CategoryHelper.cs
+++ b/src/AnEoT.Vintage/Helpers/CategoryHelper.cs
@@ -28,7 +28,7 @@ public static class CategoryHelper
                 string markdown = File.ReadAllText(file.FullName);
                 ArticleInfo articleInfo = MarkdownHelper.GetFromFrontMatter<ArticleInfo>(markdown);
 
-                if (articleInfo.Category is not null && articleInfo.Category.Any())
+                if (articleInfo.Article && articleInfo.Category is not null && articleInfo.Category.Any())
                 {
                     foreach (string categoryString in articleInfo.Category)
                     {

--- a/src/AnEoT.Vintage/Views/Category/Detail.cshtml
+++ b/src/AnEoT.Vintage/Views/Category/Detail.cshtml
@@ -18,10 +18,10 @@
         <br>
     </div>
 
-    在此分类下，有以下文章：
+    在此分类中，有以下文章：
 
     <ul>
-        @foreach (string uri in Model.ArticleUris.Reverse())
+        @foreach (string uri in Model.ArticleUris.OrderBy(uri => uri.Split('/')[1]).Reverse())
         {
             string markdownPath = System.IO.Path.Combine(env.WebRootPath, uri);
             string markdown = File.ReadAllText(markdownPath);

--- a/src/AnEoT.Vintage/Views/__MarkdownPageTemplate.cshtml
+++ b/src/AnEoT.Vintage/Views/__MarkdownPageTemplate.cshtml
@@ -23,67 +23,72 @@
 }
 
 <div>
-    <div>
-        @if(uriParts.Any() && uriParts.Length > 1)
-        {
-            <div>
-                @for (int i = 0; i < uriParts.Length; i++)
+    @if (uriParts.Any() && uriParts.Length > 1)
+    {
+        <div>
+            @for (int i = 0; i < uriParts.Length; i++)
+            {
+                if (i != 0)
                 {
-                    if (i != 0)
-                    {
-                        <span style="margin-left:1px;margin-right:1px">/</span>
-                    }
-                    
-                    if (i != uriParts.Length - 1)
-                    {
-                        string target = string.Join('/', uriParts[..(i + 1)]);
-                        string displayTitle = @PageTitleHelper.GetPageTitle(env.WebRootPath, target);
-                        <a href="~/@target">@displayTitle</a>
-                    }
-                    else
-                    {
-                        <span>@Model.Title</span>
-                    }
+                    <span style="margin-left:1px;margin-right:1px">/</span>
                 }
-            </div>
-        }
-        <h1 style="margin-bottom:10px">@Model.Title</h1>
-        @if (uriParts.Any())
-        {
-            string target = string.Join('/', uriParts);
-            <div style="margin-bottom:10px">
-                <a href="https://aneot.terrach.net/@target">在原网站查看此页面</a>
-                <br />
-            </div>
-        }
-        <span>作者： @(string.IsNullOrWhiteSpace(articleInfo.Author) ? "Another End of Terra" : articleInfo.Author)</span>
-        <br />
-        @if (DateOnly.TryParse(articleInfo.Date, CultureInfo.InvariantCulture, out DateOnly result))
-        {
-            <span>日期： @result.ToString("yyyy年M月d日")</span>
+
+                if (i != uriParts.Length - 1)
+                {
+                    string target = string.Join('/', uriParts[..(i + 1)]);
+                    string displayTitle = @PageTitleHelper.GetPageTitle(env.WebRootPath, target);
+                    <a href="~/@target">@displayTitle</a>
+                }
+                else
+                {
+                    <span>@Model.Title</span>
+                }
+            }
+        </div>
+    }
+    <h1 style="margin-bottom:10px">@Model.Title</h1>
+    @if (uriParts.Any())
+    {
+        string target = string.Join('/', uriParts);
+        <div style="margin-bottom:10px">
+            <a href="https://aneot.terrach.net/@target">在原网站查看此页面</a>
             <br />
-        }
-        @if (articleInfo.Category is not null)
-        {
-            <span>
-                分类：@foreach (string item in articleInfo.Category)
+        </div>
+    }
+    <span>作者： @(string.IsNullOrWhiteSpace(articleInfo.Author) ? "Another End of Terra" : articleInfo.Author)</span>
+    <br />
+    @if (DateOnly.TryParse(articleInfo.Date, CultureInfo.InvariantCulture, out DateOnly result))
+    {
+        <span>日期： @result.ToString("yyyy年M月d日")</span>
+        <br />
+    }
+    @if (articleInfo.Category is not null)
+    {
+        <span>
+            分类：@foreach (string item in articleInfo.Category)
+            {
+                @if (CategoryHelper.GetAllCategories(env.WebRootPath).Contains(item))
                 {
                     <a style="margin: 0 auto 0 0;" href="~/category/@item">@item</a>
                 }
-            </span>
-            <br />
-        }
-
-        @if (articleInfo.Tag is not null)
-        {
-            <span>
-                标签：@foreach (string item in articleInfo.Tag)
+                else
                 {
-                    <span style="margin: 0 auto 0 0; text-decoration: underline;">@item</span>
+                    <span style="margin: 0 auto 0 0;">@item</span>
                 }
-            </span>
-        }
-    </div>
+            }
+        </span>
+        <br />
+    }
+
+    @if (articleInfo.Tag is not null)
+    {
+        <span>
+            标签：@foreach (string item in articleInfo.Tag)
+            {
+                <span style="margin: 0 auto 0 0; text-decoration: underline;">@item</span>
+            }
+        </span>
+    }
 </div>
 
 <div>


### PR DESCRIPTION
- 修复调用```CategoryHelper.GetAllCategories()```方法时，意外获取到不应该包含的分类的问题
- 修复分类页中，文章的排序混乱问题
- 当页面包含不应该包含的分类时，不再生成链接（如卷首语页面中，将不会对“卷首”分类生成链接）