### PR TITLE
修复 Feed 源无法被访问的问题

### DIFF
--- a/src/AnEoT.Vintage/Helpers/RssGenerationHelper.cs
+++ b/src/AnEoT.Vintage/Helpers/RssGenerationHelper.cs
@@ -175,7 +175,6 @@ namespace AnEoT.Vintage.Helpers
 
             Console.WriteLine("RSS 源生成完成！");
             Console.WriteLine($"已在以下路径生成\nRSS：{rssFilePath}\nAtom：{atomFilePath}");
-            Console.WriteLine($"路径指向的文件是否存在\nRSS：{File.Exists(rssFilePath)}\nAtom：{File.Exists(atomFilePath)}");
         }
     }
 

--- a/src/AnEoT.Vintage/Program.cs
+++ b/src/AnEoT.Vintage/Program.cs
@@ -133,9 +133,11 @@ public class Program
 
         if (generateStaticWebSite)
         {
-            //添加静态网站生成服务
-            StaticResourcesInfoProvider provider = StaticWebSiteHelper.GetStaticResourcesInfo(builder.Environment.WebRootPath, convertWebP);
-            builder.Services.AddSingleton<IStaticResourcesInfoProvider>(provider);
+            // 添加静态网站生成服务
+            builder.Services.AddSingleton<IStaticResourcesInfoProvider>(provider =>
+            {
+                return StaticWebSiteHelper.GetStaticResourcesInfo(builder.Environment.WebRootPath, convertWebP);
+            });
 
             if (convertWebP)
             {
@@ -244,7 +246,7 @@ public class Program
 
         if (generateStaticWebSite)
         {
-            //生成静态网页文件
+            // 生成静态网页文件
             app.GenerateStaticContent(staticWebSiteOutputPath, exitWhenDone: true);
         }
 


### PR DESCRIPTION
- 修复 Feed 源无法被访问的问题

---

此问题的原因如下：

此项目的静态网页生成需要指定哪些文件需要添加到 AspNetStatic 中，然后才能进行生成。

然而，这个过程是在 Feed 源生成过程之前执行的，这意味着在收集完要添加到静态网页生成的文件列表后，Feed 源才会生成。

我们现在更改了添加 StaticResourcesInfoProvider 这个静态网页资源的方式：

原先我们构造一个新的实例，然后添加到依赖注入容器中；现在我们使用  `Func<IServiceProvider, TService>` 以在启动静态网页生成时才会创建 StaticResourcesInfoProvider（Feed 源生成是在静态网页生成之前就完成了）。