### PR TITLE
修复 IE 5 不能正确加载 JS 脚本的问题

### DIFF
--- a/src/AnEoT.Vintage/wwwroot/js/cookies.js
+++ b/src/AnEoT.Vintage/wwwroot/js/cookies.js
@@ -91,5 +91,5 @@ var docCookies = {
             aKeys[nIdx] = decodeURIComponent(aKeys[nIdx]);
         }
         return aKeys;
-    },
+    }
 };


### PR DESCRIPTION
- 修复 IE 5 因“SCRIPT1028: 缺少标识符、字符串或数字”而不能正确加载 JS 脚本的问题