### PR TITLE
修复期刊列表页中 Vol.01 封面图像路径的问题

### DIFF
--- a/src/AnEoT.Vintage/wwwroot/posts/README.md
+++ b/src/AnEoT.Vintage/wwwroot/posts/README.md
@@ -26,7 +26,7 @@ dir:
 
 ## **往期回顾** {.centering}
 
-|![](./2022-05/res/cover.webp)|![](./2022-06//res/cover.webp)|![](./2022-07/res/cover.webp)|
+|![](./2022-05/res/cover.webp)|![](./2022-06/res/cover.webp)|![](./2022-07/res/cover.webp)|
 |:-:|:-:|:-:|
 |[2022-05: Vol. Special <br>绿华漫霜优秀作品集](2022-05/)|[2022-06: Vol.01 <br>2022 年 06 月号](2022-06/)|[2022-07: Vol.02 <br>2022 年 07 月号：相互的彼方](2022-07/)|
 |![](./2022-08/res/cover.webp)|![](./2022-09/res/cover.webp)|![](./2022-10/res/cover.webp)|


### PR DESCRIPTION
- 修复期刊列表页中 Vol.01 封面图像路径的问题

跟随原仓库更新的 Commit：
2ced79c => 79e7a67